### PR TITLE
Fix flaw in DiffLineBackgroundRenderer

### DIFF
--- a/source/AehnlichViewLib/Controls/AvalonEditEx/DiffLineBackgroundRenderer.cs
+++ b/source/AehnlichViewLib/Controls/AvalonEditEx/DiffLineBackgroundRenderer.cs
@@ -83,7 +83,7 @@
 
                 if (brush != default(SolidColorBrush))
                 {
-                    foreach (var rc in BackgroundGeometryBuilder.GetRectsFromVisualSegment(textView, v, 0, (int)_DiffView.ActualWidth))
+                    foreach (var rc in BackgroundGeometryBuilder.GetRectsFromVisualSegment(textView, v, 0, v.VisualLength))
                     {
                         drawingContext.DrawRectangle(brush, BorderlessPen,
                             new Rect(0, rc.Top, textView.ActualWidth, rc.Height));


### PR DESCRIPTION
GetRectsFromVisualSegment needs a line length for the endVC parameter instead of a control width.

This fixes incomplete background rendering in cases where word wrap is active and some lines are wrapping across over a larger range of display lines (about > 10).

Great work otherwise!!!